### PR TITLE
adding the original path as an env var

### DIFF
--- a/lib/context.go
+++ b/lib/context.go
@@ -96,7 +96,7 @@ func (c *Context) setGOPATH() error {
 	if err := os.Setenv("GOPATH", c.tmpPath); err != nil {
 		return err
 	}
-    if err := os.Setenv("REAL_GOPATH", c.origPath); err != nil {
+    if err := os.Setenv("ORIG_GOPATH", c.origPath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I've created this environment variable to get back to my real gopath since it's overwritten at runtime.  I use mocktest with gocov and creates this problem descibed here:
https://github.com/axw/gocov/issues/52

If i dont use "mocktest", this works fine.  With mocktest I can't get the package dir using build.Import(), it returns an empty string "".  The GOPATH environment variable is also set to the withmock tmp dir.

I'm not sure if this is the best approach to solve my problem but it works since I can grab the original path.  Let me know if there is a better solution or it makes sense to merge this back into your master branch. 

thanks,
Isaac
